### PR TITLE
PsIni Module NameValuePairs Pram is now of type Hashtable and wont ac…

### DIFF
--- a/ImageFactoryV3-Build.ps1
+++ b/ImageFactoryV3-Build.ps1
@@ -360,30 +360,30 @@ Foreach($Ref in $RefTaskSequenceIDs){
     $IniFile = "$($Settings.settings.MDT.DeploymentShare)\Control\CustomSettings.ini"
     $CustomSettings = Get-IniContent -FilePath $IniFile -CommentChar ";"
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "OSDComputerName=$Ref"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"OSDComputerName"="$Ref"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "TaskSequenceID=$Ref"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"TaskSequenceID"="$Ref"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "BackupFile=$Ref.wim"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"BackupFile"="$Ref.wim"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "SkipTaskSequence=YES"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"SkipTaskSequence"="YES"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "SkipApplications=YES"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"SkipApplications"="YES"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
-    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "SkipCapture=YES"
+    $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"SkipCapture"="YES"}
     Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
 
     if($TestMode -eq $True){
-        $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "DoCapture=NO"
+        $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"DoCapture"="NO"}
         Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
     }
     else{
-        $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs "DoCapture=YES"
+        $CSIniUpdate = Set-IniContent -FilePath $IniFile -Sections "$BIOSSerialNumber" -NameValuePairs @{"DoCapture"="YES"}
         Out-IniFile -FilePath $IniFile -Force -Encoding ASCII -InputObject $CSIniUpdate
     }
 }


### PR DESCRIPTION
Hi Mikael, Awesome work! I had issue running your script against the latest PsIni https://github.com/lipkau/PsIni.

I was getting type conversation error between system.string and type hashtable. looking at the PSIni  NameValuePairs is now of type HashTable.

https://github.com/lipkau/PsIni/wiki/Set-IniContent
NameValuePairs
This parameter specifies a Hashtable of one or more key names and values to modify. If they don't exist, they will be added. Type: HashTable This parameter must be provided.


